### PR TITLE
Downgrade compileSdk to 30

### DIFF
--- a/androidApp/main/app/build.gradle.kts
+++ b/androidApp/main/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
 
-    compileSdk = 30
+    compileSdk = 32
 
     defaultConfig {
         applicationId = "com.simplecityapps.shuttle"

--- a/androidApp/main/app/build.gradle.kts
+++ b/androidApp/main/app/build.gradle.kts
@@ -11,12 +11,12 @@ plugins {
 
 android {
 
-    compileSdk = 32
+    compileSdk = 30
 
     defaultConfig {
         applicationId = "com.simplecityapps.shuttle"
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
         versionName = versionName()
         versionCode = versionCode()
         vectorDrawables.useSupportLibrary = true

--- a/androidApp/main/core/build.gradle
+++ b/androidApp/main/core/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
         buildConfigField("String", "PROXY_ADDR", "\"192.168.0.14\"")
         buildConfigField("Integer", "PROXY_PORT", "8888")
     }

--- a/androidApp/main/core/build.gradle
+++ b/androidApp/main/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/imageloader/build.gradle
+++ b/androidApp/main/imageloader/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/androidApp/main/imageloader/build.gradle
+++ b/androidApp/main/imageloader/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/mediaprovider/core/build.gradle
+++ b/androidApp/main/mediaprovider/core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/mediaprovider/core/build.gradle
+++ b/androidApp/main/mediaprovider/core/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary true

--- a/androidApp/main/mediaprovider/emby/build.gradle
+++ b/androidApp/main/mediaprovider/emby/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/androidApp/main/mediaprovider/emby/build.gradle
+++ b/androidApp/main/mediaprovider/emby/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/mediaprovider/jellyfin/build.gradle
+++ b/androidApp/main/mediaprovider/jellyfin/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/androidApp/main/mediaprovider/jellyfin/build.gradle
+++ b/androidApp/main/mediaprovider/jellyfin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/mediaprovider/local/build.gradle
+++ b/androidApp/main/mediaprovider/local/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/androidApp/main/mediaprovider/local/build.gradle
+++ b/androidApp/main/mediaprovider/local/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/mediaprovider/plex/build.gradle
+++ b/androidApp/main/mediaprovider/plex/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/androidApp/main/mediaprovider/plex/build.gradle
+++ b/androidApp/main/mediaprovider/plex/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/networking/build.gradle
+++ b/androidApp/main/networking/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/androidApp/main/networking/build.gradle
+++ b/androidApp/main/networking/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/playback/build.gradle
+++ b/androidApp/main/playback/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/androidApp/main/playback/build.gradle
+++ b/androidApp/main/playback/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/recyclerview-adapter/build.gradle
+++ b/androidApp/main/recyclerview-adapter/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/recyclerview-adapter/build.gradle
+++ b/androidApp/main/recyclerview-adapter/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/androidApp/main/remote-config/build.gradle.kts
+++ b/androidApp/main/remote-config/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 32
 
     defaultConfig {
         minSdk = 21

--- a/androidApp/main/remote-config/build.gradle.kts
+++ b/androidApp/main/remote-config/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 30
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/androidApp/main/saf/build.gradle
+++ b/androidApp/main/saf/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
         consumerProguardFiles 'consumer-rules.pro'
     }
 

--- a/androidApp/main/saf/build.gradle
+++ b/androidApp/main/saf/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/androidApp/main/trial/build.gradle
+++ b/androidApp/main/trial/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 30
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/androidApp/main/trial/build.gradle
+++ b/androidApp/main/trial/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/shared/data/build.gradle.kts
+++ b/shared/data/build.gradle.kts
@@ -48,11 +48,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 30
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
     }
 }

--- a/shared/data/build.gradle.kts
+++ b/shared/data/build.gradle.kts
@@ -48,7 +48,7 @@ kotlin {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 32
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
     defaultConfig {

--- a/shared/database/build.gradle.kts
+++ b/shared/database/build.gradle.kts
@@ -53,10 +53,10 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 30
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
     }
 }

--- a/shared/database/build.gradle.kts
+++ b/shared/database/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 32
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 21

--- a/shared/main/build.gradle.kts
+++ b/shared/main/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 32
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 21

--- a/shared/main/build.gradle.kts
+++ b/shared/main/build.gradle.kts
@@ -41,10 +41,10 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 30
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
     }
 }

--- a/shared/parcel/build.gradle.kts
+++ b/shared/parcel/build.gradle.kts
@@ -43,11 +43,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 30
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 32
+        targetSdk = 30
     }
 }

--- a/shared/parcel/build.gradle.kts
+++ b/shared/parcel/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 32
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 
     defaultConfig {


### PR DESCRIPTION
..to resolve ForegroundServiceStartNotAllowedException

Google decided to break apps targetting API31+ by introducing a new crash

See
https://developer.android.com/guide/components/foreground-services#background-start-restrictions

Classic Google behaviour. The simplest solution at present is to roll back to API 30

Resolves #71 