### PR TITLE
Fixed a crash on API 31 (Foreground Service)

### DIFF
--- a/androidApp/main/playback/src/main/java/com/simplecityapps/playback/audiofocus/AudioFocusHelper.kt
+++ b/androidApp/main/playback/src/main/java/com/simplecityapps/playback/audiofocus/AudioFocusHelper.kt
@@ -13,6 +13,8 @@ interface AudioFocusHelper {
 
     var enabled: Boolean
 
+    var resumeOnFocusGain: Boolean
+
     interface Listener {
 
         fun restoreVolumeAndPlay()

--- a/androidApp/main/playback/src/main/java/com/simplecityapps/playback/audiofocus/AudioFocusHelperBase.kt
+++ b/androidApp/main/playback/src/main/java/com/simplecityapps/playback/audiofocus/AudioFocusHelperBase.kt
@@ -18,7 +18,7 @@ abstract class AudioFocusHelperBase(
         context.getSystemService()
     }
 
-    private var resumeOnFocusGain: Boolean = false
+    override var resumeOnFocusGain: Boolean = false
 
     private var isPlaying: Boolean = false
 


### PR DESCRIPTION
Google introduced a new type of crash, where the system kills your app if you try to start a foreground service without any input from the user.

This happens when audio focus is regained after transient focus loss (like a phone call), and we try to start the foreground service again.

The solution is to not stop the foreground service when pausing due to transient focus loss