### PR TITLE
Remove local playlists when removing S2 Media Provider

### DIFF
--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/onboarding/mediaprovider/MediaProviderSelectionPresenter.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/onboarding/mediaprovider/MediaProviderSelectionPresenter.kt
@@ -4,6 +4,7 @@ import com.simplecityapps.localmediaprovider.local.provider.mediastore.MediaStor
 import com.simplecityapps.localmediaprovider.local.provider.taglib.TaglibMediaProvider
 import com.simplecityapps.mediaprovider.MediaImporter
 import com.simplecityapps.mediaprovider.MediaProvider
+import com.simplecityapps.mediaprovider.repository.playlists.PlaylistRepository
 import com.simplecityapps.mediaprovider.repository.songs.SongRepository
 import com.simplecityapps.playback.PlaybackManager
 import com.simplecityapps.playback.persistence.PlaybackPreferenceManager
@@ -42,6 +43,7 @@ class MediaProviderSelectionPresenter @AssistedInject constructor(
     private val jellyfinMediaProvider: JellyfinMediaProvider,
     private val plexMediaProvider: PlexMediaProvider,
     private val songRepository: SongRepository,
+    private val playlistRepository: PlaylistRepository,
     private val queueManager: QueueManager,
     private val playbackManager: PlaybackManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
@@ -99,6 +101,7 @@ class MediaProviderSelectionPresenter @AssistedInject constructor(
 
         appCoroutineScope.launch {
             songRepository.removeAll(mediaProviderType)
+            playlistRepository.deleteAll(mediaProviderType)
         }
     }
 

--- a/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
@@ -18,6 +18,7 @@ interface PlaylistRepository {
     suspend fun removeSongsFromPlaylist(playlist: Playlist, songs: List<Song>)
     fun getSongsForPlaylist(playlist: Playlist): Flow<List<PlaylistSong>>
     suspend fun deletePlaylist(playlist: Playlist)
+    suspend fun deleteAll(mediaProviderType: MediaProviderType)
     suspend fun clearPlaylist(playlist: Playlist)
     suspend fun renamePlaylist(playlist: Playlist, name: String)
     fun getSmartPlaylists(): Flow<List<SmartPlaylist>>

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/data/room/dao/PlaylistDataDao.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/data/room/dao/PlaylistDataDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import com.simplecityapps.localmediaprovider.local.data.room.entity.PlaylistData
+import com.simplecityapps.shuttle.model.MediaProviderType
 import com.simplecityapps.shuttle.model.Playlist
 import kotlinx.coroutines.flow.Flow
 
@@ -47,4 +48,7 @@ abstract class PlaylistDataDao {
 
     @Query("DELETE FROM playlists WHERE id = :playlistId")
     abstract suspend fun delete(playlistId: Long)
+
+    @Query("DELETE FROM playlists WHERE mediaProvider = :mediaProviderType")
+    abstract suspend fun deleteAll(mediaProviderType: MediaProviderType)
 }

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
@@ -122,6 +122,10 @@ class LocalPlaylistRepository(
         return playlistDataDao.delete(playlist.id)
     }
 
+    override suspend fun deleteAll(mediaProviderType: MediaProviderType) {
+        return playlistDataDao.deleteAll(mediaProviderType)
+    }
+
     override suspend fun clearPlaylist(playlist: Playlist) {
         return playlistDataDao.clear(playlist.id)
     }


### PR DESCRIPTION
Closes #113 

With this PR, removing a local provider not only removes the associated songs, but also the associated playlists.