### PR TITLE
Automatically add songOrder to playlists

### DIFF
--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/data/room/dao/PlaylistSongJoinDao.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/data/room/dao/PlaylistSongJoinDao.kt
@@ -13,11 +13,20 @@ import kotlinx.coroutines.flow.map
 @Dao
 abstract class PlaylistSongJoinDao {
 
-    @Insert
-    abstract suspend fun insert(playlistSongJoin: PlaylistSongJoin)
+    // Add a song at the end of the playlist.
+    @Query(
+        // Inspired from https://stackoverflow.com/a/6982330
+        """
+            INSERT INTO playlist_song_join (playlistId, songId, sortOrder)
+            VALUES (
+                :playlistId,
+                :songId,
+	            (SELECT IFNULL(MAX(sortOrder),-1)+1 FROM playlist_song_join WHERE playlistId = :playlistId)
+            )
+        """
+    )
+    abstract suspend fun appendSong(playlistId: Long, songId: Long)
 
-    @Insert
-    abstract suspend fun insert(playlistSongJoins: List<PlaylistSongJoin>)
 
     @Query(
         """

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
@@ -80,21 +80,18 @@ class LocalPlaylistRepository(
                 externalId = externalId
             )
         )
-        playlistSongJoinDao.insert(songs.orEmpty().map { song -> PlaylistSongJoin(playlistId, song.id) })
+        songs.orEmpty().map { song ->
+            playlistSongJoinDao.appendSong(playlistId, song.id)
+        }
         val playlist = playlistDataDao.getPlaylist(playlistId)
         Timber.v("Created playlist: ${playlist.name} with ${playlist.songCount} songs}")
         return playlist
     }
 
     override suspend fun addToPlaylist(playlist: Playlist, songs: List<Song>) {
-        return playlistSongJoinDao.insert(
-            songs.map { song ->
-                PlaylistSongJoin(
-                    playlistId = playlist.id,
-                    songId = song.id
-                )
-            }
-        )
+        songs.map { song ->
+            playlistSongJoinDao.appendSong(playlist.id, song.id)
+        }
     }
 
     override suspend fun removeFromPlaylist(playlist: Playlist, playlistSongs: List<PlaylistSong>) {


### PR DESCRIPTION
This fixes #117

When adding songs to a playlist, let's automatically assign it a `sortOrder` so that it appears at the end of the playlist.

This does not prevent to re-order songs after they have been added.