### PR TITLE
fixup cab2de90?

### DIFF
--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
@@ -164,11 +164,13 @@ class LocalPlaylistRepository(
     override suspend fun updatePlaylistSongsSortOder(playlist: Playlist, playlistSongs: List<PlaylistSong>) {
         playlistSongJoinDao.updateSortOrder(
             playlistSongs.map { playlistSong ->
-                PlaylistSongJoin(
+                var psj = PlaylistSongJoin(
                     playlistId = playlist.id,
                     songId = playlistSong.song.id,
-                    sortOrder = playlistSong.sortOrder
+                    sortOrder = playlistSong.sortOrder,
                 )
+                psj.id = playlistSong.id
+                psj
             }
         )
     }


### PR DESCRIPTION
Hi @timusus 

It seems cab2de9061dde6a6018e8e4881e29bed061aa615 has introduced a bug in #119. I'm not totally sure why. This PR works around it, but I wished you could rather understand why (and tell me whether this workaround is acceptable, or whether you'd be able to fix the root cause).

When setting the new song order, a list of items is given to the (`@Update`) function `updateSortOrder()`. For some reason, this automatic implementation fails. E.g. it tries the following (I have logged the requests using [this technique](https://stackoverflow.com/a/66201676)):

    SQL Query: BEGIN DEFERRED TRANSACTION SQL Args: []
    SQL Query: UPDATE OR ABORT `playlist_song_join` SET `playlistId` = ?,`songId` = ?,`sortOrder` = ?,`id` = ? WHERE `id` = ? SQL Args: [21, 31030, 0, 0, 0]
    SQL Query: UPDATE OR ABORT `playlist_song_join` SET `playlistId` = ?,`songId` = ?,`sortOrder` = ?,`id` = ? WHERE `id` = ? SQL Args: [21, 31034, 4, 0, 0]
    SQL Query: UPDATE OR ABORT `playlist_song_join` SET `playlistId` = ?,`songId` = ?,`sortOrder` = ?,`id` = ? WHERE `id` = ? SQL Args: [21, 31029, 6, 0, 0]
    SQL Query: UPDATE OR ABORT `playlist_song_join` SET `playlistId` = ?,`songId` = ?,`sortOrder` = ?,`id` = ? WHERE `id` = ? SQL Args: [21, 31033, 8, 0, 0]
    uid=10264(com.simplecityapps.shuttle.dev) pool-8-thread-1 identical 4 lines
    SQL Query: UPDATE OR ABORT `playlist_song_join` SET `playlistId` = ?,`songId` = ?,`sortOrder` = ?,`id` = ? WHERE `id` = ? SQL Args: [21, 31033, 8, 0, 0]
    (End of transaction)

Note how it (unsuccessfully) tries to update the sort order of song 31033.
Also, not sure why it assigns them orders 0, 4, 6, 8 although it should assingn them orders 1, 2, 3, 4...

Anyway, it does not succeed to re-order all the songs, and silently fails (which means the playlist sticks to its original order).
Implementing it the naive way (see this PR) now works. But that definitely looks like a dirty workaround. Would you have any better suggestion?