### PR TITLE
Update playlist stale values

### DIFF
--- a/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaImporter.kt
+++ b/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaImporter.kt
@@ -292,6 +292,11 @@ class MediaImporter(
                     playlistUpdateData.externalId
                 )
             } else {
+                // Update possibly stale values
+                playlistRepository.renamePlaylist(existingPlaylist, playlistUpdateData.name)
+                playlistRepository.updatePlaylistMediaProviderType(existingPlaylist, playlistUpdateData.mediaProviderType)
+                playlistRepository.updatePlaylistExternalId(existingPlaylist, playlistUpdateData.externalId)
+
                 // Look for duplicates
                 val existingSongs = playlistRepository.getSongsForPlaylist(existingPlaylist)
                     .firstOrNull()

--- a/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
@@ -24,6 +24,8 @@ interface PlaylistRepository {
     fun getSmartPlaylists(): Flow<List<SmartPlaylist>>
     suspend fun updatePlaylistSortOder(playlist: Playlist, sortOrder: PlaylistSongSortOrder)
     suspend fun updatePlaylistSongsSortOder(playlist: Playlist, playlistSongs: List<PlaylistSong>)
+    suspend fun updatePlaylistMediaProviderType(playlist: Playlist, mediaProviderType: MediaProviderType)
+    suspend fun updatePlaylistExternalId(playlist: Playlist, externalId: String?)
 }
 
 enum class PlaylistSortOrder : Serializable {

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
@@ -176,4 +176,28 @@ class LocalPlaylistRepository(
             }
         )
     }
+
+    override suspend fun updatePlaylistMediaProviderType(playlist: Playlist, mediaProviderType: MediaProviderType) {
+        playlistDataDao.update(
+            PlaylistData(
+                id = playlist.id,
+                name = playlist.name,
+                sortOrder = playlist.sortOrder,
+                mediaProviderType = mediaProviderType,
+                externalId = playlist.externalId,
+            )
+        )
+    }
+
+    override suspend fun updatePlaylistExternalId(playlist: Playlist, externalId: String?) {
+        playlistDataDao.update(
+            PlaylistData(
+                id = playlist.id,
+                name = playlist.name,
+                sortOrder = playlist.sortOrder,
+                mediaProviderType = playlist.mediaProvider,
+                externalId = externalId,
+            )
+        )
+    }
 }

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/repository/LocalPlaylistRepository.kt
@@ -145,6 +145,7 @@ class LocalPlaylistRepository(
                 id = playlist.id,
                 name = name,
                 externalId = playlist.externalId,
+                mediaProviderType = playlist.mediaProvider,
                 sortOrder = playlist.sortOrder
             )
         )
@@ -156,6 +157,7 @@ class LocalPlaylistRepository(
                 id = playlist.id,
                 name = playlist.name,
                 externalId = playlist.externalId,
+                mediaProviderType = playlist.mediaProvider,
                 sortOrder = sortOrder
             )
         )


### PR DESCRIPTION
This PR adds setters (and use them) so that playlist values are kept consistent when editing some of their attributes.
Otherwise, some metadata (external ID, sort order, provider type...) could get out-of-sync when renaming, re-importing, etc. playlists.

This fixes a behaviour that could lead to bugs before #114 was merged. Now #114 is merged, I could not exhibit bugs anymore, but this PR makes S2 more robust, and may prevent future bugs.