### PR TITLE
Highlight the current song on the album detail view

### DIFF
--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/common/viewbinders/DetailSongBinder.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/common/viewbinders/DetailSongBinder.kt
@@ -71,7 +71,7 @@ class DetailSongBinder(
         override fun bind(viewBinder: DetailSongBinder, isPartial: Boolean) {
             super.bind(viewBinder, isPartial)
 
-            itemView.isActivated = viewBinder.song == viewBinder.currentSong
+            itemView.isActivated = viewBinder.song.id == viewBinder.currentSong?.id
             trackTextView.text = viewBinder.song.track?.toString()
             titleTextView.text = viewBinder.song.name
             durationTextView.text = viewBinder.song.duration.toHms("--:--")

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/common/viewbinders/DetailSongBinder.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/common/viewbinders/DetailSongBinder.kt
@@ -16,6 +16,7 @@ import com.simplecityapps.shuttle.ui.common.utils.toHms
 
 class DetailSongBinder(
     val song: Song,
+    val currentSong: Song?,
     val listener: Listener
 ) : ViewBinder,
     SectionViewBinder {
@@ -70,6 +71,7 @@ class DetailSongBinder(
         override fun bind(viewBinder: DetailSongBinder, isPartial: Boolean) {
             super.bind(viewBinder, isPartial)
 
+            itemView.isActivated = viewBinder.song == viewBinder.currentSong
             trackTextView.text = viewBinder.song.track?.toString()
             titleTextView.text = viewBinder.song.name
             durationTextView.text = viewBinder.song.duration.toHms("--:--")

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albumartists/detail/ExpandableAlbumBinder.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albumartists/detail/ExpandableAlbumBinder.kt
@@ -11,8 +11,6 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.simplecityapps.shuttle.imageloading.ArtworkImageLoader
 import com.simplecityapps.adapter.RecyclerAdapter
 import com.simplecityapps.adapter.ViewBinder
-import com.simplecityapps.shuttle.model.Album
-import com.simplecityapps.shuttle.model.Song
 import com.simplecityapps.shuttle.R
 import com.simplecityapps.shuttle.ui.common.phrase.joinSafely
 import com.simplecityapps.shuttle.ui.common.recyclerview.SectionViewBinder
@@ -159,7 +157,7 @@ class ExpandableAlbumBinder(
                         if (groupingEntry.key.isNotEmpty()) {
                             viewBinders.add(GroupingBinder(groupingEntry.key))
                         }
-                        viewBinders.addAll(groupingEntry.value.map { song -> DetailSongBinder(song, songBinderListener) })
+                        viewBinders.addAll(groupingEntry.value.map { song -> DetailSongBinder(song, null, songBinderListener) })
                         viewBinders
                     }
 

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailFragment.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailFragment.kt
@@ -237,14 +237,13 @@ class AlbumDetailFragment :
 
     // AlbumDetailContract.View Implementation
 
-    override fun setData(songs: List<com.simplecityapps.shuttle.model.Song>) {
+    override fun setData(songs: List<com.simplecityapps.shuttle.model.Song>, currentSong: Song?) {
         val discGroupingSongsMap = songs
             .groupBy { song -> song.disc ?: 1 }
             .toSortedMap()
             .mapValues { entry ->
                 entry.value.groupBy { song -> song.grouping ?: "" }
             }
-        val currentSong = presenter.getCurrentSong()
 
         adapter.update(
             discGroupingSongsMap.flatMap { discEntry ->
@@ -280,10 +279,6 @@ class AlbumDetailFragment :
 
     override fun onAddedToQueue(name: String) {
         Toast.makeText(context, Phrase.from(requireContext(), R.string.queue_item_added).put("item_name", name).format(), Toast.LENGTH_SHORT).show()
-    }
-
-    override fun onCurrentSongChanged(newCurrentSong: Song) {
-        setData(presenter.songs)
     }
 
     override fun setAlbum(album: com.simplecityapps.shuttle.model.Album) {

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailFragment.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailFragment.kt
@@ -25,6 +25,7 @@ import au.com.simplecityapps.shuttle.imageloading.ArtworkImageLoader
 import com.simplecityapps.adapter.RecyclerAdapter
 import com.simplecityapps.adapter.ViewBinder
 import com.simplecityapps.shuttle.R
+import com.simplecityapps.shuttle.model.Song
 import com.simplecityapps.shuttle.ui.common.TagEditorMenuSanitiser
 import com.simplecityapps.shuttle.ui.common.autoCleared
 import com.simplecityapps.shuttle.ui.common.autoClearedNullable
@@ -243,6 +244,7 @@ class AlbumDetailFragment :
             .mapValues { entry ->
                 entry.value.groupBy { song -> song.grouping ?: "" }
             }
+        val currentSong = presenter.getCurrentSong()
 
         adapter.update(
             discGroupingSongsMap.flatMap { discEntry ->
@@ -256,7 +258,11 @@ class AlbumDetailFragment :
                     if (groupingEntry.key.isNotEmpty()) {
                         viewBinders.add(GroupingBinder(groupingEntry.key))
                     }
-                    viewBinders.addAll(groupingEntry.value.map { song -> DetailSongBinder(song, songBinderListener) })
+                    viewBinders.addAll(
+                        groupingEntry.value.map { song ->
+                            DetailSongBinder(song, currentSong, songBinderListener)
+                        }
+                    )
                     viewBinders
                 }
 
@@ -274,6 +280,10 @@ class AlbumDetailFragment :
 
     override fun onAddedToQueue(name: String) {
         Toast.makeText(context, Phrase.from(requireContext(), R.string.queue_item_added).put("item_name", name).format(), Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onCurrentSongChanged(newCurrentSong: Song) {
+        setData(presenter.songs)
     }
 
     override fun setAlbum(album: com.simplecityapps.shuttle.model.Album) {

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
@@ -27,10 +27,9 @@ import timber.log.Timber
 interface AlbumDetailContract {
 
     interface View {
-        fun setData(songs: List<Song>)
+        fun setData(songs: List<Song>, currentSong: Song?)
         fun showLoadError(error: Error)
         fun onAddedToQueue(name: String)
-        fun onCurrentSongChanged(newCurrentSong: Song)
         fun setAlbum(album: com.simplecityapps.shuttle.model.Album)
         fun showDeleteError(error: Error)
         fun showTagEditor(songs: List<Song>)
@@ -69,8 +68,7 @@ class AlbumDetailPresenter @AssistedInject constructor(
         fun create(album: com.simplecityapps.shuttle.model.Album): AlbumDetailPresenter
     }
 
-    var songs: List<Song> = emptyList()
-        private set
+    private var songs: List<Song> = emptyList()
 
     override fun bindView(view: AlbumDetailContract.View) {
         super.bindView(view)
@@ -94,7 +92,7 @@ class AlbumDetailPresenter @AssistedInject constructor(
                 .filterNotNull()
                 .collect { songs ->
                     this@AlbumDetailPresenter.songs = songs
-                    view?.setData(songs)
+                    view?.setData(songs, getCurrentSong())
                 }
         }
     }
@@ -111,8 +109,8 @@ class AlbumDetailPresenter @AssistedInject constructor(
     }
 
     override fun onQueuePositionChanged(oldPosition: Int?, newPosition: Int?) {
-        getCurrentSong()?.let {
-            view?.onCurrentSongChanged(it)
+        getCurrentSong()?.let { currentSong ->
+            view?.setData(this@AlbumDetailPresenter.songs, currentSong)
         }
     }
 

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
@@ -22,7 +22,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 interface AlbumDetailContract {
 

--- a/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
+++ b/androidApp/main/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/detail/AlbumDetailPresenter.kt
@@ -7,7 +7,9 @@ import com.simplecityapps.mediaprovider.repository.albums.AlbumQuery
 import com.simplecityapps.mediaprovider.repository.albums.AlbumRepository
 import com.simplecityapps.mediaprovider.repository.songs.SongRepository
 import com.simplecityapps.playback.PlaybackManager
+import com.simplecityapps.playback.queue.QueueChangeCallback
 import com.simplecityapps.playback.queue.QueueManager
+import com.simplecityapps.playback.queue.QueueWatcher
 import com.simplecityapps.shuttle.R
 import com.simplecityapps.shuttle.model.Song
 import com.simplecityapps.shuttle.query.SongQuery
@@ -17,10 +19,10 @@ import com.simplecityapps.shuttle.ui.common.mvp.BasePresenter
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 interface AlbumDetailContract {
 
@@ -28,6 +30,7 @@ interface AlbumDetailContract {
         fun setData(songs: List<Song>)
         fun showLoadError(error: Error)
         fun onAddedToQueue(name: String)
+        fun onCurrentSongChanged(newCurrentSong: Song)
         fun setAlbum(album: com.simplecityapps.shuttle.model.Album)
         fun showDeleteError(error: Error)
         fun showTagEditor(songs: List<Song>)
@@ -41,6 +44,7 @@ interface AlbumDetailContract {
         fun addToQueue(song: Song)
         fun playNext(album: com.simplecityapps.shuttle.model.Album)
         fun playNext(song: Song)
+        fun getCurrentSong(): Song?
         fun exclude(song: Song)
         fun editTags(song: Song)
         fun editTags(album: com.simplecityapps.shuttle.model.Album)
@@ -54,20 +58,24 @@ class AlbumDetailPresenter @AssistedInject constructor(
     private val songRepository: SongRepository,
     private val playbackManager: PlaybackManager,
     private val queueManager: QueueManager,
+    private val queueWatcher: QueueWatcher,
     @Assisted private val album: com.simplecityapps.shuttle.model.Album
 ) : BasePresenter<AlbumDetailContract.View>(),
-    AlbumDetailContract.Presenter {
+    AlbumDetailContract.Presenter,
+    QueueChangeCallback {
 
     @AssistedInject.Factory
     interface Factory {
         fun create(album: com.simplecityapps.shuttle.model.Album): AlbumDetailPresenter
     }
 
-    private var songs: List<Song> = emptyList()
+    var songs: List<Song> = emptyList()
+        private set
 
     override fun bindView(view: AlbumDetailContract.View) {
         super.bindView(view)
 
+        queueWatcher.addCallback(this)
         view.setAlbum(album)
 
         launch {
@@ -99,6 +107,12 @@ class AlbumDetailPresenter @AssistedInject constructor(
                     result.onFailure { error -> view?.showLoadError(error as Error) }
                 }
             }
+        }
+    }
+
+    override fun onQueuePositionChanged(oldPosition: Int?, newPosition: Int?) {
+        getCurrentSong()?.let {
+            view?.onCurrentSongChanged(it)
         }
     }
 
@@ -139,6 +153,10 @@ class AlbumDetailPresenter @AssistedInject constructor(
             playbackManager.playNext(listOf(song))
             view?.onAddedToQueue(song.name ?: context.getString(R.string.unknown))
         }
+    }
+
+    override fun getCurrentSong(): Song? {
+        return queueManager.getCurrentItem()?.song
     }
 
     override fun exclude(song: Song) {

--- a/androidApp/main/app/src/main/res/layout/list_item_detail_song.xml
+++ b/androidApp/main/app/src/main/res/layout/list_item_detail_song.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?selectableItemBackground"
+    android:background="@drawable/bg_queue_item"
     android:clickable="true"
     android:focusable="true"
     android:minHeight="48dp"

--- a/shared/data/src/commonMain/kotlin/com/simplecityapps/shuttle/model/Song.kt
+++ b/shared/data/src/commonMain/kotlin/com/simplecityapps/shuttle/model/Song.kt
@@ -71,19 +71,4 @@ data class Song(
     } else {
         null
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Song
-
-        if (id != other.id) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return id.hashCode()
-    }
 }

--- a/shared/data/src/commonMain/kotlin/com/simplecityapps/shuttle/model/Song.kt
+++ b/shared/data/src/commonMain/kotlin/com/simplecityapps/shuttle/model/Song.kt
@@ -71,4 +71,19 @@ data class Song(
     } else {
         null
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Song
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
 }


### PR DESCRIPTION
Until now, when playing an album, there was no way to view on the album detail view which song was playing. With these changes, now the current playing song is highlighted with a light blue background, like in the queue list. This way it's easier for the user to find the current point in the album.