### PR TITLE
Playlist import compares path case-insensitively

### DIFF
--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
@@ -124,7 +124,7 @@ class TaglibMediaProvider(
                                 songPath.equals(entry.location, ignoreCase = true) -> {
                                     true
                                 }
-                                songPath.length > lowercaseEntryLocation.length -> {
+                                songPath.length > entry.location.length -> {
                                     songPath.contains(other = entry.location, ignoreCase = true)
                                 }
                                 else -> {

--- a/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
+++ b/androidApp/main/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
@@ -89,11 +89,7 @@ class TaglibMediaProvider(
     ): Flow<FlowEvent<List<MediaImporter.PlaylistUpdateData>, MessageProgress>> {
         return flow {
 
-            val sanitisedSongPaths = existingSongs.associateBy {
-                Uri.decode(it.path.substringAfterLast('/'))
-                    .substringAfterLast(':')
-                    .lowercase()
-            }
+            val sanitisedSongPaths = existingSongs.associateBy { Uri.decode(it.path.substringAfterLast('/')).substringAfterLast(':') }
 
             getDocumentNodes()?.let { nodes ->
                 val m3uPlaylists = nodes
@@ -123,17 +119,16 @@ class TaglibMediaProvider(
                             )
                         )
 
-                        val lowercaseEntryLocation = entry.location.lowercase()
                         sanitisedSongPaths.keys.firstOrNull { songPath ->
                             when {
-                                songPath == lowercaseEntryLocation -> {
+                                songPath.equals(entry.location, ignoreCase = true) -> {
                                     true
                                 }
                                 songPath.length > lowercaseEntryLocation.length -> {
-                                    songPath.contains(lowercaseEntryLocation)
+                                    songPath.contains(other = entry.location, ignoreCase = true)
                                 }
                                 else -> {
-                                    lowercaseEntryLocation.contains(songPath)
+                                    entry.location.contains(other = songPath, ignoreCase = true)
                                 }
                             }
                         }?.let { matchingPath ->


### PR DESCRIPTION
When generated on a Windows machine (where the filesystem paths are case-insensitive), M3U files may contain paths that do not exactly match the filesystem names. E.g., the M3U file can reference `Music/John John/Song.mp3`, while the actual file is stored as `music/John john/song.MP3`

Until now, this prevented S2 to correctly import the playlist (as this file would be silently ignored).
This MR fixes this issue. Such files are now correctly imported.