### PR TITLE
Fix about libraries crash

### DIFF
--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/opensource/LicensesDialogFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/opensource/LicensesDialogFragment.kt
@@ -30,10 +30,10 @@ class LicensesDialogFragment : DialogFragment() {
         recyclerView.adapter = adapter
 
         val libraries = Libs.Builder()
-                .withContext(requireContext())
-                .build()
-                .libraries
-                .sortedBy { library -> library.name }
+            .withContext(requireContext())
+            .build()
+            .libraries
+            .sortedBy { library -> library.name }
 
         adapter.update(
             libraries.map { LibraryBinder(it, listener) }

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/opensource/LicensesDialogFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/opensource/LicensesDialogFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
+import com.mikepenz.aboutlibraries.util.withContext
 import com.simplecityapps.adapter.RecyclerAdapter
 import com.simplecityapps.shuttle.R
 import com.simplecityapps.shuttle.ui.common.autoCleared
@@ -28,8 +29,8 @@ class LicensesDialogFragment : DialogFragment() {
         adapter = RecyclerAdapter(lifecycleScope)
         recyclerView.adapter = adapter
 
-        val libraries =
-            Libs.Builder()
+        val libraries = Libs.Builder()
+                .withContext(requireContext())
                 .build()
                 .libraries
                 .sortedBy { library -> library.name }


### PR DESCRIPTION
This resolves a crash when attempting to open the licenses dialog. Due to an issue with the AboutLibraries plugin, the libraries are currently empty.

See https://github.com/mikepenz/AboutLibraries/issues/839