### PR TITLE
Update m3u files

### DIFF
--- a/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaImporter.kt
+++ b/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaImporter.kt
@@ -81,7 +81,7 @@ class MediaImporter(
             return
         }
 
-        Timber.v("Starting import..")
+        Timber.v("Starting import...")
         val time = System.currentTimeMillis()
 
         isImporting = true

--- a/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
+++ b/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/playlists/PlaylistRepository.kt
@@ -6,6 +6,7 @@ import com.simplecityapps.shuttle.model.PlaylistSong
 import com.simplecityapps.shuttle.model.SmartPlaylist
 import com.simplecityapps.shuttle.model.Song
 import com.simplecityapps.shuttle.sorting.PlaylistSongSortOrder
+import java.io.OutputStream
 import java.io.Serializable
 import kotlinx.coroutines.flow.Flow
 
@@ -70,6 +71,8 @@ interface PlaylistRepository {
         playlist: Playlist,
         externalId: String?
     )
+
+    suspend fun updateM3uFile(playlist: Playlist)
 }
 
 enum class PlaylistSortOrder : Serializable {

--- a/android/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
+++ b/android/mediaprovider/local/src/main/java/com/simplecityapps/localmediaprovider/local/provider/taglib/TaglibMediaProvider.kt
@@ -150,7 +150,7 @@ class TaglibMediaProvider(
                                 mediaProviderType = type,
                                 name = m3uPlaylist.name,
                                 songs = songs,
-                                externalId = m3uPlaylist.name
+                                externalId = m3uPlaylist.path
                             )
                         updateData
                     } else {


### PR DESCRIPTION
Hello @timusus 

This MR resolves #112 .

I have been using this code for a while now, and it suits my needs.

**What it does**
When using an S2 Media Store, when adding or removing or reordering songs to a playlist that initially came from an .m3u file on the disk, the underlying .m3u file gets updated on disk.
This way, the .m3u files are kept in sync with the Shuttle2 database.

**What it doesn't do**
* Does not work with Android Media Store (I think). That does not sound like a problem, because this store does not allow importing m3u files in the first place
* The following are (I think) hard to do because of limitations in the Android API:
    * It does not delete the .m3u file when a playlist is deleted (i.e. when `deletePlaylist` or `deleteAll` are called).
    * It does not rename .m3u files when a playlist is renamed (i.e. when `renamePlaylist` is called)
    * It does not create an .m3u file when a playlist is created. Which means (among other things) that it only tracks playlists that have been imported from the storage in the first place. 


**Notes**
* I'm not sure how to add unit/integration tests for this feature. This may be left for future work in an upcoming MR.
* This is a behaviour I always want. Maybe some users would prefer not having the .m3u files synced? In this case, maybe the user-facing dialog when creating a S2 Media Store may contain an opt-out checkbox to disable this?


I'd be happy to have your thoughts on this!