### PR TITLE
Enable sorting genres by song count

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -264,6 +264,8 @@ android {
 
 
         testImplementation(libs.junit)
+        testImplementation(libs.mockk)
+        testImplementation(libs.kotlinx.coroutines.test)
 
         // WorkManager
         implementation(libs.androidx.work.runtime.ktx)

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/SortPreferenceManager.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/SortPreferenceManager.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import com.simplecityapps.shuttle.persistence.get
 import com.simplecityapps.shuttle.persistence.put
 import com.simplecityapps.shuttle.sorting.AlbumSortOrder
+import com.simplecityapps.shuttle.sorting.GenreSortOrder
 import com.simplecityapps.shuttle.sorting.SongSortOrder
 import timber.log.Timber
 
@@ -30,6 +31,19 @@ class SortPreferenceManager(private val sharedPreferences: SharedPreferences) {
             } catch (e: IllegalArgumentException) {
                 Timber.e(e, "Failed to retrieve sort order")
                 AlbumSortOrder.AlbumName
+            }
+        }
+
+    var sortOrderGenreList: GenreSortOrder
+        set(value) {
+            sharedPreferences.put("sort_order_genre_list", value.name)
+        }
+        get() {
+            return try {
+                GenreSortOrder.valueOf(sharedPreferences.get("sort_order_genre_list", GenreSortOrder.Name.name))
+            } catch (e: IllegalArgumentException) {
+                Timber.e(e, "Failed to retrieve sort order")
+                GenreSortOrder.Name
             }
         }
 }

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/genres/GenreList.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/genres/GenreList.kt
@@ -16,12 +16,14 @@ import androidx.compose.ui.unit.dp
 import com.simplecityapps.mediaprovider.Progress
 import com.simplecityapps.shuttle.model.Genre
 import com.simplecityapps.shuttle.model.Playlist
+import com.simplecityapps.shuttle.sorting.GenreSortOrder
 import com.simplecityapps.shuttle.ui.screens.playlistmenu.PlaylistData
 
 @Composable
 fun GenreList(
     viewState: GenreListViewModel.ViewState,
     playlists: List<Playlist>,
+    setToolbarMenu: (sortOrder: GenreSortOrder) -> Unit,
     setLoadingState: (GenreListFragment.LoadingState) -> Unit,
     setLoadingProgress: (progress: Progress?) -> Unit,
     onSelectGenre: (genre: Genre) -> Unit,
@@ -49,6 +51,8 @@ fun GenreList(
             } else {
                 setLoadingState(GenreListFragment.LoadingState.None)
             }
+
+            setToolbarMenu(viewState.sortOrder)
 
             GenreList(
                 genres = viewState.genres,

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/genres/GenreListFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/genres/GenreListFragment.kt
@@ -2,6 +2,9 @@ package com.simplecityapps.shuttle.ui.screens.library.genres
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
@@ -16,11 +19,13 @@ import com.simplecityapps.mediaprovider.Progress
 import com.simplecityapps.shuttle.R
 import com.simplecityapps.shuttle.model.Genre
 import com.simplecityapps.shuttle.model.Song
+import com.simplecityapps.shuttle.sorting.GenreSortOrder
 import com.simplecityapps.shuttle.ui.common.autoCleared
 import com.simplecityapps.shuttle.ui.common.dialog.TagEditorAlertDialog
 import com.simplecityapps.shuttle.ui.common.error.userDescription
 import com.simplecityapps.shuttle.ui.common.view.CircularLoadingView
 import com.simplecityapps.shuttle.ui.common.view.HorizontalLoadingView
+import com.simplecityapps.shuttle.ui.common.view.findToolbarHost
 import com.simplecityapps.shuttle.ui.screens.library.genres.detail.GenreDetailFragmentArgs
 import com.simplecityapps.shuttle.ui.screens.playlistmenu.CreatePlaylistDialogFragment
 import com.simplecityapps.shuttle.ui.screens.playlistmenu.PlaylistData
@@ -47,6 +52,12 @@ class GenreListFragment :
     private lateinit var playlistMenuView: PlaylistMenuView
 
     // Lifecycle
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setHasOptionsMenu(true)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -82,6 +93,9 @@ class GenreListFragment :
             ) {
                 GenreList(
                     viewState = viewState,
+                    setToolbarMenu = { sortOrder ->
+                        updateToolbarMenu(sortOrder)
+                    },
                     playlists = playlistMenuPresenter.playlists,
                     setLoadingState = {
                         setLoadingState(it)
@@ -135,10 +149,45 @@ class GenreListFragment :
         }
     }
 
+    override fun onCreateOptionsMenu(
+        menu: Menu,
+        inflater: MenuInflater
+    ) {
+        super.onCreateOptionsMenu(menu, inflater)
+
+        inflater.inflate(R.menu.menu_genre_list, menu)
+    }
+
     override fun onDestroyView() {
         playlistMenuPresenter.unbindView()
 
         super.onDestroyView()
+    }
+
+    // Toolbar item selection
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.sortGenreName -> {
+            viewModel.setSortOrder(GenreSortOrder.Name)
+            true
+        }
+        R.id.sortSongCount -> {
+            viewModel.setSortOrder(GenreSortOrder.SongCount)
+            true
+        }
+        else -> false
+    }
+
+    private fun updateToolbarMenu(sortOrder: GenreSortOrder) {
+        findToolbarHost()?.toolbar?.menu?.let { menu ->
+            when (sortOrder) {
+                GenreSortOrder.Name -> menu.findItem(R.id.sortGenreName)?.isChecked = true
+                GenreSortOrder.SongCount -> menu.findItem(R.id.sortSongCount)?.isChecked = true
+                else -> {
+                    // Nothing to do
+                }
+            }
+        }
     }
 
     fun onAddedToQueue(genre: Genre) {

--- a/android/app/src/main/res/menu/menu_genre_list.xml
+++ b/android/app/src/main/res/menu/menu_genre_list.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/genreSortOrder"
+        android:icon="@drawable/ic_baseline_sort_24"
+        android:title="@string/menu_title_sort_by"
+        app:showAsAction="never">
+
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                    android:id="@+id/sortGenreName"
+                    android:title="@string/menu_title_sort_name" />
+                <item
+                    android:id="@+id/sortSongCount"
+                    android:title="@string/menu_title_sort_song_count" />
+            </group>
+        </menu>
+    </item>
+</menu>

--- a/android/app/src/main/res/values-de/strings_menu.xml
+++ b/android/app/src/main/res/values-de/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Song-Name</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Jahr</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Name</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">"Liedanzahl"</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Dauer</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-en-rGB/strings_menu.xml
+++ b/android/app/src/main/res/values-en-rGB/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Song Name</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Year</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Name</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Song Count</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duration</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-es-rES/strings_menu.xml
+++ b/android/app/src/main/res/values-es-rES/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nombre de canción</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Año</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nombre</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Número de canciones</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duración</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-es/strings_menu.xml
+++ b/android/app/src/main/res/values-es/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nombre de canción</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Año</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nombre</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Número de canciones</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duración</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-fr/strings_menu.xml
+++ b/android/app/src/main/res/values-fr/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Titre de chanson</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Année</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nom</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Nombre de chansons</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Durée</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-hi/strings_menu.xml
+++ b/android/app/src/main/res/values-hi/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">गीत का नाम</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">साल</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">"नाम "</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">गानों की संख्या</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">समयांतराल</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-it/strings_menu.xml
+++ b/android/app/src/main/res/values-it/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nome della canzone</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Anno</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nome</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Numero di canzoni</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Durata</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-ja/strings_menu.xml
+++ b/android/app/src/main/res/values-ja/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">曲名</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">年</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">"名前"</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">曲数</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">再生時間</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-nl/strings_menu.xml
+++ b/android/app/src/main/res/values-nl/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Titel van een liedje</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Jaar</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Naam</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Aantal nummers</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Looptijd</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-pl/strings_menu.xml
+++ b/android/app/src/main/res/values-pl/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nazwa piosenki</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Rok</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Imię</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Liczba piosenek</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Trwanie</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-pt-rBR/strings_menu.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nome da música</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Ano</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nome</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Quantidade de músicas</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duração</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-pt-rPT/strings_menu.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Nome da música</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Ano</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Nome</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Número de músicas</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duração</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-ru/strings_menu.xml
+++ b/android/app/src/main/res/values-ru/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Название песни</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Год</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">"Имя"</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Количество песен</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Продолжительность</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-tr/strings_menu.xml
+++ b/android/app/src/main/res/values-tr/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Şarkı Adı</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Yıl</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">İsim</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Şarkı sayısı</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Şarkı Süresi</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values-zh-rCN/strings_menu.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">歌曲名称</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">年份</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">名字</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">歌曲数量</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">时长</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/main/res/values/strings_menu.xml
+++ b/android/app/src/main/res/values/strings_menu.xml
@@ -46,6 +46,10 @@
     <string name="menu_title_sort_song_name">Song Name</string>
     <!-- Menu option to sort by year-->
     <string name="menu_title_sort_year">Year</string>
+    <!-- Menu option to sort by name -->
+    <string name="menu_title_sort_name">Name</string>
+    <!-- Menu option to sort by song count -->
+    <string name="menu_title_sort_song_count">Song Count</string>
     <!-- Menu option to sort by song duration -->
     <string name="menu_title_sort_duration">Duration</string>
     <!-- Menu option to sort by last modified date -->

--- a/android/app/src/test/java/com/simplecityapps/app/GenreListTest.kt
+++ b/android/app/src/test/java/com/simplecityapps/app/GenreListTest.kt
@@ -1,0 +1,174 @@
+package com.simplecityapps.app
+
+import com.simplecityapps.mediaprovider.MediaImportObserver
+import com.simplecityapps.mediaprovider.SongImportState
+import com.simplecityapps.mediaprovider.repository.genres.GenreRepository
+import com.simplecityapps.mediaprovider.repository.songs.SongRepository
+import com.simplecityapps.playback.PlaybackManager
+import com.simplecityapps.playback.queue.QueueManager
+import com.simplecityapps.shuttle.model.Genre
+import com.simplecityapps.shuttle.model.MediaProviderType
+import com.simplecityapps.shuttle.persistence.GeneralPreferenceManager
+import com.simplecityapps.shuttle.sorting.GenreSortOrder
+import com.simplecityapps.shuttle.ui.screens.library.SortPreferenceManager
+import com.simplecityapps.shuttle.ui.screens.library.genres.GenreListViewModel
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GenreListTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val mediaProviders = listOf(MediaProviderType.MediaStore)
+
+    private val genreRepository = mockk<GenreRepository>()
+    private val songRepository = mockk<SongRepository>()
+    private val playbackManager = mockk<PlaybackManager>()
+    private val queueManager = mockk<QueueManager>()
+    private val sortPreferenceManager = mockk<SortPreferenceManager>()
+    private val preferenceManager = mockk<GeneralPreferenceManager>()
+    private val mediaImportObserver = mockk<MediaImportObserver>()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        every { sortPreferenceManager.sortOrderGenreList } returns GenreSortOrder.Default
+        every { sortPreferenceManager.sortOrderGenreList = any() } just Runs
+
+        every { mediaImportObserver.songImportState } returns
+            MutableStateFlow(SongImportState.ImportComplete(MediaProviderType.MediaStore, ""))
+        every { preferenceManager.theme(any()) } returns MutableStateFlow(GeneralPreferenceManager.Theme.Dark)
+        every { preferenceManager.accent(any()) } returns MutableStateFlow(GeneralPreferenceManager.Accent.Default)
+        every { preferenceManager.extraDark(any()) } returns MutableStateFlow(false)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun sortsOnInitPerPreferences() = runTest {
+        // Arbitrary list
+        val sortedGenres = listOf(
+            Genre(name = "Classical", 3, 10, mediaProviders),
+            Genre(name = "Electronic", 2, 10, mediaProviders),
+            Genre(name = "Rock", 1, 10, mediaProviders)
+        )
+        // Mock the output of the repository, matching the mocked sortOrderGenreList value
+        every { genreRepository.getGenres(match { it.sortOrder == GenreSortOrder.Default }) } returns flowOf(sortedGenres)
+
+        val viewModel = GenreListViewModel(
+            genreRepository,
+            songRepository,
+            playbackManager,
+            queueManager,
+            sortPreferenceManager,
+            preferenceManager,
+            mediaImportObserver
+        )
+
+        // Wait until ready, then capture state
+        val result = viewModel.viewState.first { it is GenreListViewModel.ViewState.Ready }
+
+        assertTrue(result is GenreListViewModel.ViewState.Ready)
+        result as GenreListViewModel.ViewState.Ready
+        // Assert that the view model state genres equal the repository output
+        assertEquals(sortedGenres, result.genres)
+    }
+
+    @Test
+    fun sortsByName() = runTest {
+        val genres = listOf(
+            Genre(name = "Pop", 1, 10, mediaProviders),
+            Genre(name = "Ambient", 2, 10, mediaProviders),
+            Genre(name = "Metal", 3, 10, mediaProviders)
+        )
+        every { genreRepository.getGenres(any()) } returns flowOf(genres)
+
+        val viewModel = GenreListViewModel(
+            genreRepository,
+            songRepository,
+            playbackManager,
+            queueManager,
+            sortPreferenceManager,
+            preferenceManager,
+            mediaImportObserver
+        )
+
+        // Wait until ready
+        viewModel.viewState.first { it is GenreListViewModel.ViewState.Ready }
+
+        viewModel.setSortOrder(GenreSortOrder.Name)
+
+        // Capture next emitted state
+        val result = viewModel.viewState.drop(1).first()
+
+        assertTrue(result is GenreListViewModel.ViewState.Ready)
+        result as GenreListViewModel.ViewState.Ready
+        assertEquals(
+            listOf(
+                Genre(name = "Ambient", 2, 10, mediaProviders),
+                Genre(name = "Metal", 3, 10, mediaProviders),
+                Genre(name = "Pop", 1, 10, mediaProviders)
+            ),
+            result.genres
+        )
+    }
+
+    @Test
+    fun sortsBySongCount() = runTest {
+        val genres = listOf(
+            Genre(name = "Pop", 1, 10, mediaProviders),
+            Genre(name = "Ambient", 2, 10, mediaProviders),
+            Genre(name = "Metal", 3, 10, mediaProviders)
+        )
+        every { genreRepository.getGenres(any()) } returns flowOf(genres)
+
+        val viewModel = GenreListViewModel(
+            genreRepository,
+            songRepository,
+            playbackManager,
+            queueManager,
+            sortPreferenceManager,
+            preferenceManager,
+            mediaImportObserver
+        )
+
+        // Wait until ready
+        viewModel.viewState.first { it is GenreListViewModel.ViewState.Ready }
+
+        viewModel.setSortOrder(GenreSortOrder.SongCount)
+
+        // Capture next emitted state
+        val result = viewModel.viewState.drop(1).first()
+
+        assertTrue(result is GenreListViewModel.ViewState.Ready)
+        result as GenreListViewModel.ViewState.Ready
+        assertEquals(
+            listOf(
+                Genre(name = "Metal", 3, 10, mediaProviders),
+                Genre(name = "Ambient", 2, 10, mediaProviders),
+                Genre(name = "Pop", 1, 10, mediaProviders)
+            ),
+            result.genres
+        )
+    }
+}

--- a/android/data/src/main/kotlin/com/simplecityapps/shuttle/sorting/GenreSortOrder.kt
+++ b/android/data/src/main/kotlin/com/simplecityapps/shuttle/sorting/GenreSortOrder.kt
@@ -1,5 +1,7 @@
 package com.simplecityapps.shuttle.sorting
 
 enum class GenreSortOrder {
-    Default
+    Default,
+    Name,
+    SongCount
 }

--- a/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/genres/GenreComparator.kt
+++ b/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/repository/genres/GenreComparator.kt
@@ -4,12 +4,17 @@ import com.simplecityapps.shuttle.model.Genre
 import com.simplecityapps.shuttle.sorting.GenreSortOrder
 
 val GenreSortOrder.comparator: Comparator<Genre>
-    get() {
-        return when (this) {
-            GenreSortOrder.Default -> GenreComparator.defaultComparator
-        }
+    get() = when (this) {
+        GenreSortOrder.Default -> GenreComparator.defaultComparator
+        GenreSortOrder.Name -> GenreComparator.nameComparator
+        GenreSortOrder.SongCount -> GenreComparator.songCountComparator
     }
 
 object GenreComparator {
-    val defaultComparator: Comparator<Genre> by lazy { compareBy { genre -> genre.name } }
+    val defaultComparator: Comparator<Genre> = compareBy { it.name }
+
+    val nameComparator: Comparator<Genre> = compareBy { it.name }
+
+    val songCountComparator: Comparator<Genre> = compareByDescending<Genre> { it.songCount }
+        .then(defaultComparator)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ kotlin = "2.1.0"
 kotlinx-coroutines-android = "1.8.1"
 kotlinx-coroutines-core = "1.8.1"
 kotlinx-coroutines-play-services = "1.8.1"
+kotlinx-coroutines-test = "1.8.1"
 kotlinx-datetime = "0.4.1"
 ktaglib = "1.5"
 leakcanary-android = "2.10"
@@ -44,6 +45,7 @@ lifecycle-viewmodel-compose = "2.8.7"
 logging-interceptor = "4.12.0"
 material = "1.12.0"
 media = "1.7.0"
+mockk = "1.14.2"
 moshi = "1.15.1"
 moshi-adapters = "1.15.0"
 moshi-kotlin = "1.15.0"
@@ -138,9 +140,11 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 kotlinx-coroutinesAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines-core" }
 kotlinx-coroutinesPlayServices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines-play-services" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary-android" }
 mikepenz-aboutlibrariesCore = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-adapters = { module = "com.squareup.moshi:moshi-adapters", version.ref = "moshi-adapters" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi-kotlin" }


### PR DESCRIPTION
Adds a menu to the genre list to enable toggling sorting genres between song count and name (the previous default), and saves the option to shared preferences.

Sorting by song count is useful for finding music from your favorite genres, especially if your music library has many. For this use case, and for the sake of simplicity, the sort is only in descending order.

I manually added some translations for the new menu options, but I'm not sure of their accuracy or if the translations are already managed in some other way.

I added a few unit tests, which require some added libraries, for the sake of my own practise if nothing else.