### PR TITLE
Support hidden images files (artist/cover)

### DIFF
--- a/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectoryAlbumArtistLocalArtworkModelLoader.kt
+++ b/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectoryAlbumArtistLocalArtworkModelLoader.kt
@@ -89,7 +89,7 @@ class DirectoryAlbumArtistLocalArtworkModelLoader(
         }
 
         companion object {
-            private val pattern by lazy { Pattern.compile("artist.*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
+            private val pattern by lazy { Pattern.compile("(\.?)artist.*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
         }
     }
 }

--- a/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectoryAlbumLocalArtworkModelLoader.kt
+++ b/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectoryAlbumLocalArtworkModelLoader.kt
@@ -81,7 +81,7 @@ class DirectoryAlbumLocalArtworkModelLoader(
         }
 
         companion object {
-            private val pattern by lazy { Pattern.compile("(folder|cover|album).*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
+            private val pattern by lazy { Pattern.compile("(\.?(folder|cover|album)).*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
         }
     }
 }

--- a/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectorySongLocalArtworkModelLoader.kt
+++ b/android/imageloader/src/main/java/au/com/simplecityapps/shuttle/imageloading/glide/loader/local/DirectorySongLocalArtworkModelLoader.kt
@@ -67,7 +67,7 @@ class DirectorySongLocalArtworkModelLoader(
         }
 
         companion object {
-            private val pattern by lazy { Pattern.compile("(folder|cover|album).*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
+            private val pattern by lazy { Pattern.compile("(\.?(folder|cover|album)).*\\.(jpg|jpeg|png|webp)", Pattern.CASE_INSENSITIVE) }
         }
     }
 }


### PR DESCRIPTION
This is a really quick fix for the regex pattern that searches images.

My galery app is filled with folders, one for each album. It would be the end of the story if it was only in the galery, since I can group/hide folders. Other applications that relies on fetching images from the phone show as well all the different folders (one for each album cover art).

There are two solutions:
1. Embed the cover art in the file
2. Hide the file to Android

I'm not a fan of embedding the cover art in the music files because I have hi-res covers that are multiple Mb in size. So my solution is to hide the file to Android `.cover.png`. I just tested it and S2 doesn't find it, hence this quick fix PR.