### PR TITLE
Fix playback when song file name contains '#'

### DIFF
--- a/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaInfoProvider.kt
+++ b/android/mediaprovider/core/src/main/java/com/simplecityapps/mediaprovider/MediaInfoProvider.kt
@@ -2,6 +2,7 @@ package com.simplecityapps.mediaprovider
 
 import android.net.Uri
 import com.simplecityapps.shuttle.model.Song
+import java.io.File
 
 data class MediaInfo(val path: Uri, val mimeType: String, val isRemote: Boolean)
 
@@ -30,7 +31,12 @@ class AggregateMediaInfoProvider(val providers: MutableSet<MediaInfoProvider> = 
         song: Song,
         castCompatibilityMode: Boolean
     ): MediaInfo {
-        val uri = Uri.parse(song.path)
+        val uri: Uri =
+            if (song.path.startsWith("content://")) {
+                Uri.parse(song.path)
+            } else {
+                Uri.fromFile(File(song.path))
+            }
         return providers.firstOrNull { it.handles(uri) }?.getMediaInfo(song, castCompatibilityMode)
             ?: MediaInfo(path = uri, mimeType = song.mimeType, isRemote = false)
     }


### PR DESCRIPTION
It only happens when using the with Android media store provider.

It would interpret the # as a fragment and fail to open the file. I doesn't happen with S2 media provider as song paths are already escaped URIs.

Fixes #209 