### PR TITLE
Fix crash when scrolling to the bottom of the Songs tab list (from Library)

### DIFF
--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/songs/SongList.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/songs/SongList.kt
@@ -182,7 +182,13 @@ private fun SongList(
             modifier = Modifier.fillMaxSize().padding(vertical = 8.dp),
             state = state,
             getPopupText = { index ->
-                getFastscrollPopupText(songs[index], sortOrder)
+                // Offset by 1 for the shuffle item
+                val songIndex = index - 1
+                if (songIndex in songs.indices) {
+                    getFastscrollPopupText(songs[songIndex], sortOrder)
+                } else {
+                    ""
+                }
             },
             popup = getFastscrollPopup(sortOrder)
         )


### PR DESCRIPTION
This happened when scrolling by dragging the scrollbar handle.

It was due to not taking into account the first item is Shuffle, which isn't in the songs list. Apply the same fix as in the Albums list.