### PR TITLE
Exit selection mode when back button is pressed on Library tabs

### DIFF
--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albumartists/AlbumArtistListFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albumartists/AlbumArtistListFragment.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.widget.SwitchCompat
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -63,10 +65,17 @@ class AlbumArtistListFragment :
 
     private lateinit var playlistMenuView: PlaylistMenuView
 
+    private var onBackPressedCallback: OnBackPressedCallback? = null
+
     // Lifecycle
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        onBackPressedCallback = requireActivity().onBackPressedDispatcher
+            .addCallback(this, false) {
+                viewModel.clearSelection()
+            }
 
         setHasOptionsMenu(true)
     }
@@ -98,12 +107,12 @@ class AlbumArtistListFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState
                     .collect { state ->
-                        val count = state.selectedArtists.size
-                        if (count == 0) {
-                            contextualToolbarHelper.hide()
-                        } else {
+                        if (state.isSelecting) {
+                            onBackPressedCallback?.isEnabled = true
+
                             contextualToolbarHelper.show()
 
+                            val count = state.selectedArtists.size
                             contextualToolbarHelper.contextualToolbar?.title =
                                 Phrase.fromPlural(requireContext(), R.plurals.multi_select_items_selected, count)
                                     .put("count", count)
@@ -116,6 +125,9 @@ class AlbumArtistListFragment :
                                         .distinct(),
                                 )
                             }
+                        } else {
+                            onBackPressedCallback?.isEnabled = false
+                            contextualToolbarHelper.hide()
                         }
 
                         updateToolbarMenuViewMode(state.viewMode)

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/AlbumListFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/albums/AlbumListFragment.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.widget.SwitchCompat
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -64,10 +66,17 @@ class AlbumListFragment :
 
     private lateinit var playlistMenuView: PlaylistMenuView
 
+    private var onBackPressedCallback: OnBackPressedCallback? = null
+
     // Lifecycle
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        onBackPressedCallback = requireActivity().onBackPressedDispatcher
+            .addCallback(this, false) {
+                viewModel.clearSelection()
+            }
 
         setHasOptionsMenu(true)
     }
@@ -99,12 +108,12 @@ class AlbumListFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState
                     .collect { state ->
-                        val count = state.selectedAlbums.size
-                        if (count == 0) {
-                            contextualToolbarHelper.hide()
-                        } else {
+                        if (state.isSelecting) {
+                            onBackPressedCallback?.isEnabled = true
+
                             contextualToolbarHelper.show()
 
+                            val count = state.selectedAlbums.size
                             contextualToolbarHelper.contextualToolbar?.title =
                                 Phrase.fromPlural(requireContext(), R.plurals.multi_select_items_selected, count)
                                     .put("count", count)
@@ -117,6 +126,9 @@ class AlbumListFragment :
                                         .distinct(),
                                 )
                             }
+                        } else {
+                            onBackPressedCallback?.isEnabled = false
+                            contextualToolbarHelper.hide()
                         }
 
                         updateToolbarMenuViewMode(state.viewMode)

--- a/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/songs/SongListFragment.kt
+++ b/android/app/src/main/java/com/simplecityapps/shuttle/ui/screens/library/songs/SongListFragment.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 import androidx.appcompat.widget.SwitchCompat
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -64,10 +66,17 @@ class SongListFragment :
 
     private lateinit var playlistMenuView: PlaylistMenuView
 
+    private var onBackPressedCallback: OnBackPressedCallback? = null
+
     // Lifecycle
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        onBackPressedCallback = requireActivity().onBackPressedDispatcher
+            .addCallback(this, false) {
+                viewModel.clearSelection()
+            }
 
         setHasOptionsMenu(true)
     }
@@ -99,12 +108,12 @@ class SongListFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState
                     .collect { state ->
-                        val count = state.selectedSongs.size
-                        if (count == 0) {
-                            contextualToolbarHelper.hide()
-                        } else {
+                        if (state.isSelecting) {
+                            onBackPressedCallback?.isEnabled = true
+
                             contextualToolbarHelper.show()
 
+                            val count = state.selectedSongs.size
                             contextualToolbarHelper.contextualToolbar?.title =
                                 Phrase.fromPlural(requireContext(), R.plurals.multi_select_items_selected, count)
                                     .put("count", count)
@@ -117,6 +126,9 @@ class SongListFragment :
                                         .distinct(),
                                 )
                             }
+                        } else {
+                            onBackPressedCallback?.isEnabled = false
+                            contextualToolbarHelper.hide()
                         }
 
                         updateToolbarMenuSortOrder(state.sortOrder)


### PR DESCRIPTION
Implements it for Artists, Albums and Songs tabs. Genres and Playlists don't support selecting items. Previously, this would close the application.

Ideally, we should also have a back button (<-) in the selection toolbar doing the same, but I think it's better left until this part is migrated to Compose.

